### PR TITLE
Add tool to ingest Debian Security CVE files

### DIFF
--- a/src/glvd/cli/ingest_debsec.py
+++ b/src/glvd/cli/ingest_debsec.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from ..database import Base, DistCpe, DebsecCve
+from ..data.debsec_cve import DebsecCveFile
+
+
+logger = logging.getLogger(__name__)
+
+
+class IngestDebsec:
+    class DistCpeMapper:
+        cpe_vendor: str
+        cpe_product: str
+
+        def __call__(self, codename: str) -> DistCpe:
+            raise NotImplementedError
+
+    # XXX: Move mapper somewhere else
+    class DistCpeMapperDebian(DistCpeMapper):
+        cpe_vendor = 'debian'
+        cpe_product = 'debian_linux'
+
+        def __call__(self, codename: str) -> DistCpe:
+            version: str = {
+                'woody': '3.0',
+                'sarge': '3.1',
+                'etch': '4.0',
+                'lenny': '5.0',
+                'squeeze': '6.0',
+                'wheezy': '7',
+                'jessie': '8',
+                'stretch': '9',
+                'buster': '10',
+                'bullseye': '11',
+                'bookworm': '12',
+                'trixie': '13',
+                'forky': '14',
+                '': '',
+            }[codename]
+            return DistCpe(
+                cpe_vendor='debian',
+                cpe_product='debian_linux',
+                cpe_version=version,
+                deb_codename=codename,
+            )
+
+    class DistCpeMapperGardenlinux(DistCpeMapper):
+        cpe_vendor = 'sap'
+        cpe_product = 'gardenlinux'
+
+        def __call__(self, codename: str) -> DistCpe:
+            return DistCpe(
+                cpe_vendor='sap',
+                cpe_product='gardenlinux',
+                cpe_version=codename,
+                deb_codename=codename,
+            )
+
+    dist_cpe_mapper: dict[str, DistCpeMapper] = {
+        'debian': DistCpeMapperDebian(),
+        'gardenlinux': DistCpeMapperGardenlinux(),
+    }
+
+    def __init__(self, cpe_product: str, path: Path) -> None:
+        self.path = path
+
+        self.dist_base = self.dist_cpe_mapper[cpe_product]
+
+    def read_cve(self) -> DebsecCveFile:
+        r = DebsecCveFile()
+        with (self.path / 'CVE' / 'list').open('r') as f:
+            r.read(f)
+        return r
+
+    async def import_cve_update(
+        self,
+        session: AsyncSession,
+        file_cve: DebsecCveFile,
+    ) -> None:
+        # Find all existing entries for all versions of given product
+        stmt = (
+            select(DebsecCve)
+            .join(DebsecCve.dist)
+            .where(DistCpe.cpe_vendor == self.dist_base.cpe_vendor)
+            .where(DistCpe.cpe_product == self.dist_base.cpe_product)
+        )
+
+        async for r in await session.stream(stmt):
+            entry = r[0]
+
+            new_entries = file_cve.get(entry.dist.deb_codename)
+            if not new_entries:
+                continue
+            new_entry = new_entries.pop((entry.cve_id, entry.deb_source), None)
+            if not new_entry:
+                # XXX: Delete entry
+                continue
+
+            # Update object in place. Only real changes will be commited
+            entry.merge(new_entry)
+
+    async def import_cve_insert(
+        self,
+        session: AsyncSession,
+        file_cve: DebsecCveFile,
+    ) -> None:
+        # Find all existing versions of given product
+        stmt = (
+            select(DistCpe)
+            .where(DistCpe.cpe_vendor == self.dist_base.cpe_vendor)
+            .where(DistCpe.cpe_product == self.dist_base.cpe_product)
+        )
+
+        dists = {
+            i[0].deb_codename: i[0]
+            async for i in await session.stream(stmt)
+        }
+
+        # We ignore some dists we can't handle
+        file_cve.pop('experimental', None)
+
+        for dist_codename, dist_entries in file_cve.items():
+            dist = dists.get(dist_codename)
+
+            # Generate a new dist entry if we have non yet
+            if not dist:
+                dist = dists[dist_codename] = self.dist_base(dist_codename)
+                session.add(dist)
+
+            for entry in dist_entries.values():
+                entry.dist = dist
+                session.add(entry)
+
+    async def import_cve(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        file_cve = self.read_cve()
+
+        await self.import_cve_update(session, file_cve)
+        await self.import_cve_insert(session, file_cve)
+
+    async def __call__(
+        self,
+        engine: AsyncEngine,
+    ) -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with async_sessionmaker(engine)() as session:
+            await self.import_cve(session)
+            await session.commit()
+
+
+if __name__ == '__main__':
+    import argparse
+    logging.basicConfig(level=logging.DEBUG)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'cpe_product',
+        choices=sorted(IngestDebsec.dist_cpe_mapper.keys()),
+        help=f'CPE product used for data, supported: {" ".join(sorted(IngestDebsec.dist_cpe_mapper.keys()))}',
+        metavar='CPE_PRODUCT',
+    )
+    parser.add_argument(
+        'dir',
+        help='data directory out of https://salsa.debian.org/security-tracker-team/security-tracker',
+        metavar='DEBSEC',
+        type=Path,
+    )
+    args = parser.parse_args()
+    engine = create_async_engine(
+        "postgresql+asyncpg:///",
+        echo=True,
+    )
+    ingest = IngestDebsec(args.cpe_product, args.dir)
+    asyncio.run(ingest(engine))

--- a/src/glvd/data/debsec_cve.py
+++ b/src/glvd/data/debsec_cve.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import re
+from typing import TextIO
+
+from ..database import DebsecCve
+
+
+class DebsecCveFile(dict[str, dict[tuple[str, str], DebsecCve]]):
+    __re = re.compile(r'''
+        ^(?:
+            (?P<id>[A-Z0-9-]+)
+            (?:\s+[\[(].*?[\])])?
+            |
+            \s+
+            (?:
+                (?:REJECTED|RESERVED|NOT-FOR-US|TODO|NOTE)(?::\s.*)?
+                |
+                \{.*\}
+                |
+                (?:\[(?P<codename>\S+)\]\s+)?
+                -\s+
+                (?P<source>[a-zA-Z0-9.+-]+)\s+
+                (?:
+                    \<(?P<tag>[a-z-]+)\>
+                    |
+                    (?P<version_fixed>[A-Za-z0-9.+~:-]+)
+                )
+                (?:\s+\((?P<note>.*?)\))?
+            )
+        )$
+    ''', re.VERBOSE)
+
+    def _read_source(self, cve_id: str, match: re.Match) -> None:
+        per_codename = self.setdefault(match['codename'] or '', {})
+
+        # We don't care if a package does not exist
+        if (tag := match['tag']) == 'removed':
+            return
+
+        per_codename[cve_id, match['source']] = DebsecCve(
+            cve_id=cve_id,
+            dist=None,
+            deb_source=match['source'],
+            deb_version_fixed=match['version_fixed'],
+            debsec_tag=tag,
+            debsec_note=match['note'],
+        )
+
+    def read(self, f: TextIO) -> None:
+        for line in f.readlines():
+            if match := self.__re.match(line):
+                if i := match['id']:
+                    current_id = i
+                elif match['source']:
+                    self._read_source(current_id, match)
+            else:
+                raise RuntimeError(f'Unable to read line: {line}')
+
+
+if __name__ == '__main__':
+    import sys
+
+    d = DebsecCveFile()
+    with open(sys.argv[1]) as f:
+        d.read(f)
+
+    for codename, entries in d.items():
+        print(f'Codename: {codename}')
+        for entry in entries.values():
+            print(f'  {entry!r}')

--- a/src/glvd/database/__init__.py
+++ b/src/glvd/database/__init__.py
@@ -3,14 +3,29 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import (
+    Any,
+    Optional,
+    Self,
+)
 
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy.types import DateTime, Text
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    MappedAsDataclass,
+    mapped_column,
+    relationship,
+)
+from sqlalchemy.sql import func
+from sqlalchemy.types import (
+    DateTime,
+    Text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 
 
-class Base(DeclarativeBase):
+class Base(MappedAsDataclass, DeclarativeBase):
     type_annotation_map = {
         str: Text,
         datetime: DateTime(timezone=True),
@@ -24,3 +39,32 @@ class NvdCve(Base):
     cve_id: Mapped[str] = mapped_column(primary_key=True)
     last_mod: Mapped[datetime]
     data: Mapped[Any]
+
+
+class DistCpe(Base):
+    __tablename__ = 'dist_cpe'
+
+    id: Mapped[int] = mapped_column(init=False, primary_key=True)
+    cpe_vendor: Mapped[str]
+    cpe_product: Mapped[str]
+    cpe_version: Mapped[str]
+    deb_codename: Mapped[str]
+
+
+class DebsecCve(Base):
+    __tablename__ = 'debsec_cve'
+
+    dist_id = mapped_column(ForeignKey(DistCpe.id), primary_key=True)
+    cve_id: Mapped[str] = mapped_column(primary_key=True)
+    last_mod: Mapped[datetime] = mapped_column(init=False, server_default=func.now(), onupdate=func.now())
+    deb_source: Mapped[str] = mapped_column(primary_key=True)
+    deb_version_fixed: Mapped[Optional[str]] = mapped_column(default=None)
+    debsec_tag: Mapped[Optional[str]] = mapped_column(default=None)
+    debsec_note: Mapped[Optional[str]] = mapped_column(default=None)
+
+    dist: Mapped[Optional[DistCpe]] = relationship(lazy='selectin', default=None)
+
+    def merge(self, other: Self) -> None:
+        self.deb_version_fixed = other.deb_version_fixed
+        self.debsec_tag = other.debsec_tag
+        self.debsec_note = other.debsec_note

--- a/tests/cli/test_ingest_debsec.py
+++ b/tests/cli/test_ingest_debsec.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+
+from sqlalchemy import select
+
+from glvd.cli.ingest_debsec import IngestDebsec
+from glvd.database import DebsecCve
+from glvd.data.debsec_cve import DebsecCveFile
+
+
+class TestIngestDebsec:
+    async def test_import_cve(self, db_session):
+        f = DebsecCveFile()
+        f[''] = {
+            ('TEST-1', 'hello'): DebsecCve(
+                cve_id='TEST-1',
+                deb_source='hello',
+                deb_version_fixed='2',
+            )
+        }
+        f['bookworm'] = {
+            ('TEST-1', 'hello'): DebsecCve(
+                cve_id='TEST-1',
+                deb_source='hello',
+                deb_version_fixed='1',
+            )
+        }
+
+        ingest = IngestDebsec('debian', None)
+        await ingest.import_cve_insert(db_session, f)
+
+        r = (await db_session.execute(select(DebsecCve).order_by(DebsecCve.cve_id, DebsecCve.deb_version_fixed))).all()
+        assert len(r) == 2
+        t = r.pop(0)[0]
+        assert t.cve_id == 'TEST-1'
+        assert t.dist.cpe_version == '12'
+        assert t.deb_source == 'hello'
+        assert t.deb_version_fixed == '1'
+
+        t = r.pop(0)[0]
+        assert t.cve_id == 'TEST-1'
+        assert t.dist.cpe_version == ''
+        assert t.deb_source == 'hello'
+        assert t.deb_version_fixed == '2'
+
+        f[''] = {
+            ('TEST-1', 'hello'): DebsecCve(
+                cve_id='TEST-1',
+                deb_source='hello',
+                deb_version_fixed='3',
+            )
+        }
+
+        await ingest.import_cve_update(db_session, f)
+
+        r = (await db_session.execute(select(DebsecCve).order_by(DebsecCve.cve_id, DebsecCve.deb_version_fixed))).all()
+        assert len(r) == 2
+        t = r.pop(1)[0]
+        assert t.cve_id == 'TEST-1'
+        assert t.dist.cpe_version == ''
+        assert t.deb_source == 'hello'
+        assert t.deb_version_fixed == '3'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,10 @@ import asyncio
 import uuid
 
 from sqlalchemy import event
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import (
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.sql import text
 
 from glvd.database import Base
@@ -62,3 +65,15 @@ async def db_conn(db_engine):
     async with db_engine.begin() as conn:
         yield conn
         await conn.rollback()
+
+
+@pytest.fixture
+async def db_session(db_engine):
+    '''
+    Provides an asynchronous SQLAlchemy database session.
+
+    This should never be commited, or it will affect other tests.
+    '''
+    async with async_sessionmaker(db_engine)() as session:
+        yield session
+        await session.rollback()

--- a/tests/data/test_debsec_cve.py
+++ b/tests/data/test_debsec_cve.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+from io import StringIO
+
+from glvd.data.debsec_cve import DebsecCveFile
+
+
+class TestDebsecCveFile:
+    case_fixed = StringIO('''\
+CVE-2023-39323 ()
+\t- golang-1.21 1.21.2-1
+\t- golang-1.20 1.20.9-1
+\t- golang-1.19 <unfixed>
+\t[bookworm] - golang-1.19 <no-dsa> (Minor issue)
+\t- golang-1.15 <removed>
+\t[bullseye] - golang-1.15 <no-dsa> (Minor issue)
+\t- golang-1.11 <removed>
+\t[buster] - golang-1.11 <postponed> (Limited support, follow bullseye DSAs/point-releases)
+\tNOTE: https://go.dev/issue/63211
+''')
+
+    def test_read_fixed(self):
+        f = DebsecCveFile()
+        f.read(self.case_fixed)
+
+        assert f.keys() == {'', 'bookworm', 'bullseye', 'buster'}
+        assert f[''].keys() == {
+            ('CVE-2023-39323', 'golang-1.19'),
+            ('CVE-2023-39323', 'golang-1.20'),
+            ('CVE-2023-39323', 'golang-1.21'),
+        }
+        assert f['bookworm'].keys() == {
+            ('CVE-2023-39323', 'golang-1.19'),
+        }
+        assert f['bullseye'].keys() == {
+            ('CVE-2023-39323', 'golang-1.15'),
+        }
+        assert f['buster'].keys() == {
+            ('CVE-2023-39323', 'golang-1.11'),
+        }
+
+    case_ignored = StringIO('''\
+CVE-2023-45374 (Bla Bla ..)
+\tNOT-FOR-US: MediaWiki extension
+CVE-2023-45364
+\tTODO: check
+CVE-2023-31289
+\tRESERVED
+CVE-2023-5312
+\tREJECTED
+''')
+
+    def test_read_ignored(self):
+        f = DebsecCveFile()
+        f.read(self.case_ignored)
+
+        assert f == {}


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to have all the information about CVE in Debian. This tool ingests those into a new table for later use.