### PR TITLE
Add tool to ingest Debian Sources files

### DIFF
--- a/src/glvd/cli/ingest_debsrc.py
+++ b/src/glvd/cli/ingest_debsrc.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from ..database import Base, DistCpe, Debsrc
+from ..data.debsrc import DebsrcFile
+
+
+logger = logging.getLogger(__name__)
+
+
+class IngestDebsrc:
+    class DistCpeMapper:
+        cpe_vendor: str
+        cpe_product: str
+
+        def __call__(self, codename: str) -> DistCpe:
+            raise NotImplementedError
+
+    # XXX: Move mapper somewhere else
+    class DistCpeMapperDebian(DistCpeMapper):
+        cpe_vendor = 'debian'
+        cpe_product = 'debian_linux'
+
+        def __call__(self, codename: str) -> DistCpe:
+            version: str = {
+                'woody': '3.0',
+                'sarge': '3.1',
+                'etch': '4.0',
+                'lenny': '5.0',
+                'squeeze': '6.0',
+                'wheezy': '7',
+                'jessie': '8',
+                'stretch': '9',
+                'buster': '10',
+                'bullseye': '11',
+                'bookworm': '12',
+                'trixie': '13',
+                'forky': '14',
+                '': '',
+            }[codename]
+            return DistCpe(
+                cpe_vendor='debian',
+                cpe_product='debian_linux',
+                cpe_version=version,
+                deb_codename=codename,
+            )
+
+    class DistCpeMapperGardenlinux(DistCpeMapper):
+        cpe_vendor = 'sap'
+        cpe_product = 'gardenlinux'
+
+        def __call__(self, codename: str) -> DistCpe:
+            return DistCpe(
+                cpe_vendor='sap',
+                cpe_product='gardenlinux',
+                cpe_version=codename,
+                deb_codename=codename,
+            )
+
+    dist_cpe_mapper: dict[str, DistCpeMapper] = {
+        'debian': DistCpeMapperDebian(),
+        'gardenlinux': DistCpeMapperGardenlinux(),
+    }
+
+    def __init__(self, cpe_product: str, deb_codename: str, file: Path) -> None:
+        self.file = file
+
+        self.dist = self.dist_cpe_mapper[cpe_product](deb_codename)
+
+    def read(self) -> DebsrcFile:
+        r = DebsrcFile()
+        with self.file.open('r') as f:
+            r.read(f)
+        return r
+
+    async def import_update(
+        self,
+        session: AsyncSession,
+        file: DebsrcFile,
+    ) -> None:
+        # Find all existing entries for all versions of given product
+        stmt = (
+            select(Debsrc)
+            .join(Debsrc.dist)
+            .where(DistCpe.cpe_vendor == self.dist.cpe_vendor)
+            .where(DistCpe.cpe_product == self.dist.cpe_product)
+            .where(DistCpe.deb_codename == self.dist.deb_codename)
+        )
+
+        async for r in await session.stream(stmt):
+            entry = r[0]
+
+            new_entry = file.pop(entry.deb_source, None)
+            if not new_entry:
+                # XXX: Delete entry
+                continue
+
+            # Update object in place. Only real changes will be commited
+            entry.merge(new_entry)
+
+    async def import_insert(
+        self,
+        session: AsyncSession,
+        file: DebsrcFile,
+    ) -> None:
+        # Find all existing versions of given product
+        stmt = (
+            select(DistCpe)
+            .where(DistCpe.cpe_vendor == self.dist.cpe_vendor)
+            .where(DistCpe.cpe_product == self.dist.cpe_product)
+            .where(DistCpe.deb_codename == self.dist.deb_codename)
+        )
+
+        dist = (await session.scalars(stmt)).one_or_none()
+        if not dist:
+            dist = self.dist
+            session.add(dist)
+
+        for entry in file.values():
+            entry.dist = dist
+            session.add(entry)
+
+    async def import_file(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        file_cve = self.read()
+
+        await self.import_update(session, file_cve)
+        await self.import_insert(session, file_cve)
+
+    async def __call__(
+        self,
+        engine: AsyncEngine,
+    ) -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with async_sessionmaker(engine)() as session:
+            await self.import_file(session)
+            await session.commit()
+
+
+if __name__ == '__main__':
+    import argparse
+    logging.basicConfig(level=logging.DEBUG)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'cpe_product',
+        choices=sorted(IngestDebsrc.dist_cpe_mapper.keys()),
+        help=f'CPE product used for data, supported: {" ".join(sorted(IngestDebsrc.dist_cpe_mapper.keys()))}',
+        metavar='CPE_PRODUCT',
+    )
+    parser.add_argument(
+        'deb_codename',
+        help='codename of APT archive',
+        metavar='CODENAME',
+    )
+    parser.add_argument(
+        'file',
+        help='uncompressed Sources file',
+        metavar='SOURCES',
+        type=Path,
+    )
+    args = parser.parse_args()
+    engine = create_async_engine(
+        "postgresql+asyncpg:///",
+        echo=True,
+    )
+    ingest = IngestDebsrc(args.cpe_product, args.deb_codename, args.file)
+    asyncio.run(ingest(engine))

--- a/src/glvd/data/debsrc.py
+++ b/src/glvd/data/debsrc.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import re
+from typing import TextIO
+
+from ..database import Debsrc
+
+
+class DebsrcFile(dict[str, Debsrc]):
+    __re = re.compile(r'''
+        ^(?:
+            Package:\s*(?P<source>[a-z0-9.-]+)
+            |
+            Version:\s*(?P<version>[A-Za-z0-9.+~:-]+)
+            |
+            Extra-Source-Only:\s*(?P<eso>yes)
+            |
+            (?P<eoe>)
+            |
+            # All other fields
+            [A-Za-z0-9-]+:.*
+            |
+            # Continuation field
+            \s+.*
+        )$
+    ''', re.VERBOSE)
+
+    def _read_source(self, source: str, version: str) -> None:
+        self[source] = Debsrc(
+            deb_source=source,
+            deb_version=version,
+        )
+
+    def read(self, f: TextIO) -> None:
+        current_source = current_version = None
+
+        def finish():
+            if current_source and current_version:
+                self._read_source(current_source, current_version)
+
+        for line in f.readlines():
+            if match := self.__re.match(line):
+                if i := match['source']:
+                    current_source = i
+                elif i := match['version']:
+                    current_version = i
+                elif match['eso']:
+                    current_source = current_version = None
+                elif match['eoe'] is not None:
+                    finish()
+                    current_source = current_version = None
+            else:
+                raise RuntimeError(f'Unable to read line: {line}')
+
+        finish()
+
+
+if __name__ == '__main__':
+    import sys
+
+    d = DebsrcFile()
+    with open(sys.argv[1]) as f:
+        d.read(f)
+
+    for entry in d.values():
+        print(f'{entry!r}')

--- a/src/glvd/database/__init__.py
+++ b/src/glvd/database/__init__.py
@@ -51,6 +51,20 @@ class DistCpe(Base):
     deb_codename: Mapped[str]
 
 
+class Debsrc(Base):
+    __tablename__ = 'debsrc'
+
+    dist_id = mapped_column(ForeignKey(DistCpe.id), primary_key=True)
+    last_mod: Mapped[datetime] = mapped_column(init=False, server_default=func.now(), onupdate=func.now())
+    deb_source: Mapped[str] = mapped_column(primary_key=True)
+    deb_version: Mapped[str]
+
+    dist: Mapped[Optional[DistCpe]] = relationship(lazy='selectin', default=None)
+
+    def merge(self, other: Self) -> None:
+        self.deb_version = other.deb_version
+
+
 class DebsecCve(Base):
     __tablename__ = 'debsec_cve'
 

--- a/tests/cli/test_ingest_debsrc.py
+++ b/tests/cli/test_ingest_debsrc.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+
+from sqlalchemy import select
+
+from glvd.cli.ingest_debsrc import IngestDebsrc
+from glvd.database import Debsrc
+from glvd.data.debsrc import DebsrcFile
+
+
+class TestIngestDebsrc:
+    async def test_import(self, db_session):
+        f = DebsrcFile()
+        f['test1'] = Debsrc(
+            deb_source='test1',
+            deb_version='1',
+        )
+        f['test2'] = Debsrc(
+            deb_source='test2',
+            deb_version='2',
+        )
+
+        ingest = IngestDebsrc('debian', 'bookworm', None)
+        await ingest.import_insert(db_session, f)
+
+        r = (await db_session.execute(select(Debsrc).order_by(Debsrc.deb_source))).all()
+        assert len(r) == 2
+        t = r.pop(0)[0]
+        assert t.dist.cpe_version == '12'
+        assert t.deb_source == 'test1'
+        assert t.deb_version == '1'
+
+        t = r.pop(0)[0]
+        assert t.dist.cpe_version == '12'
+        assert t.deb_source == 'test2'
+        assert t.deb_version == '2'
+
+        f['test2'] = Debsrc(
+            deb_source='test2',
+            deb_version='3',
+        )
+
+        await ingest.import_update(db_session, f)
+
+        r = (await db_session.execute(select(Debsrc).order_by(Debsrc.deb_source))).all()
+        assert len(r) == 2
+        t = r.pop(1)[0]
+        assert t.dist.cpe_version == '12'
+        assert t.deb_source == 'test2'
+        assert t.deb_version == '3'

--- a/tests/data/test_debsrc.py
+++ b/tests/data/test_debsrc.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+
+from io import StringIO
+
+from glvd.data.debsrc import DebsrcFile
+
+
+class TestDebsrcFile:
+    case = StringIO('''\
+Package: test1
+Version: 1
+Format: 3.0 (quilt)
+Files:
+ abcde 1 test1_1.dsc
+Package-List:
+ test1 deb devel optional arch=any
+
+Package: test1
+Version: 1extra
+Extra-Source-Only: yes
+Format: 3.0 (quilt)
+Files:
+ abcde 1 test2_2.dsc
+Package-List:
+ hello deb devel optional arch=any
+
+Package: test2
+Version: 2
+Format: 3.0 (quilt)
+Files:
+ abcde 1 test2_2.dsc
+Package-List:
+ hello deb devel optional arch=any
+''')
+
+    def test_read(self):
+        f = DebsrcFile()
+        f.read(self.case)
+
+        assert f.keys() == {'test1', 'test2'}
+        assert f['test1'].deb_source == 'test1'
+        assert f['test1'].deb_version == '1'
+        assert f['test2'].deb_source == 'test2'
+        assert f['test2'].deb_version == '2'


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to have all the information about available packages in Debian. This tool ingests the required information out of Sources files.