### PR TITLE
Use debversion extension to compare versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ The database needs to accessible using the default means, so `psql` should work 
 
 This should work on current Debian:
 ```
-sudo apt install postgresql-16
-sudo -u postgres psql -c "CREATE USER ${USER}; CREATE DATABASE ${USER} OWNER ${USER};"
+sudo apt install postgresql-16 postgresql-16-debversion
+sudo -u postgres psql -c "CREATE USER ${USER}; CREATE DATABASE ${USER} OWNER ${USER}; CREATE EXTENSION debversion;"
 ```
 
 ## Preparing dependencies

--- a/src/glvd/database/__init__.py
+++ b/src/glvd/database/__init__.py
@@ -24,6 +24,8 @@ from sqlalchemy.types import (
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
+from .types import DebVersion
+
 
 class Base(MappedAsDataclass, DeclarativeBase):
     type_annotation_map = {
@@ -57,7 +59,7 @@ class Debsrc(Base):
     dist_id = mapped_column(ForeignKey(DistCpe.id), primary_key=True)
     last_mod: Mapped[datetime] = mapped_column(init=False, server_default=func.now(), onupdate=func.now())
     deb_source: Mapped[str] = mapped_column(primary_key=True)
-    deb_version: Mapped[str]
+    deb_version: Mapped[str] = mapped_column(DebVersion)
 
     dist: Mapped[Optional[DistCpe]] = relationship(lazy='selectin', default=None)
 
@@ -72,7 +74,7 @@ class DebsecCve(Base):
     cve_id: Mapped[str] = mapped_column(primary_key=True)
     last_mod: Mapped[datetime] = mapped_column(init=False, server_default=func.now(), onupdate=func.now())
     deb_source: Mapped[str] = mapped_column(primary_key=True)
-    deb_version_fixed: Mapped[Optional[str]] = mapped_column(default=None)
+    deb_version_fixed: Mapped[Optional[str]] = mapped_column(DebVersion, default=None)
     debsec_tag: Mapped[Optional[str]] = mapped_column(default=None)
     debsec_note: Mapped[Optional[str]] = mapped_column(default=None)
 
@@ -91,7 +93,7 @@ class DebCve(Base):
     cve_id: Mapped[str] = mapped_column(primary_key=True)
     last_mod: Mapped[datetime] = mapped_column(init=False, server_default=func.now(), onupdate=func.now())
     deb_source: Mapped[str] = mapped_column(primary_key=True)
-    deb_version: Mapped[str]
+    deb_version: Mapped[str] = mapped_column(DebVersion)
     debsec_vulnerable: Mapped[bool]
     data_cpe_match: Mapped[Any]
 

--- a/src/glvd/database/types.py
+++ b/src/glvd/database/types.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from sqlalchemy.types import UserDefinedType
+
+
+class DebVersion(UserDefinedType):
+    cache_ok = True
+
+    def get_col_spec(self, **kw) -> str:
+        return 'debversion'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 import asyncio
 import uuid
+from unittest.mock import Mock
 
 from sqlalchemy import event
 from sqlalchemy.ext.asyncio import (
@@ -13,6 +14,12 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.sql import text
 
 from glvd.database import Base
+
+
+# Use standard types in all tests.  Extra types needs to be installed and
+# require superuser privileges.
+import glvd.database.types
+setattr(glvd.database.types.DebVersion, 'get_col_spec', Mock(return_value='text'))
 
 
 # Override with broader scope, so we can use session fixtures


### PR DESCRIPTION
**What this PR does / why we need it**:
Turns out, Debian versions have semantic and comparing them as string does not really work. Let's use the existing `debversion` extension and type, which implements proper comparison for us.