### PR TITLE
Add CPE extension to store Debian information

### DIFF
--- a/src/glvd/cli/combine_deb.py
+++ b/src/glvd/cli/combine_deb.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from ..database import Base, DistCpe, DebCve
-from ..data.cpe import Cpe
+from ..data.cpe import Cpe, CpeOtherDebian
 
 
 logger = logging.getLogger(__name__)
@@ -122,6 +122,10 @@ class CombineDeb:
                     vendor=dist.cpe_vendor,
                     product=dist.cpe_product,
                     version=dist.cpe_version,
+                    other=CpeOtherDebian(
+                        deb_source=deb_source,
+                        deb_version=deb_version,
+                    ),
                 )
 
                 cpe_match = {

--- a/src/glvd/data/cpe.py
+++ b/src/glvd/data/cpe.py
@@ -20,6 +20,36 @@ class CpePart(StrEnum):
 
 
 @dataclasses.dataclass
+class CpeOtherDebian:
+    deb_source: str | None = dataclasses.field(default=None)
+    deb_version: str | None = dataclasses.field(default=None)
+
+    @classmethod
+    def parse(cls, cpe: Cpe) -> str | CpeOtherDebian | CpeAny | None:
+        if not (cpe.part, cpe.vendor, cpe.product) in [
+            (CpePart.OS, 'debian', 'debian_linux'),
+            (CpePart.OS, 'sap', 'gardenlinux'),
+        ] or not isinstance(cpe.other, str):
+            return cpe.other
+
+        try:
+            kw: dict[str, str | None] = {}
+            for f in cpe.other.split(','):
+                k, v = f.split('=', 1)
+                kw[k] = v
+            return cls(**kw)
+        except ValueError:
+            return cpe.other
+
+    def __str__(self) -> str:
+        m: list[str] = []
+        for field in dataclasses.fields(self):
+            if j := getattr(self, field.name):
+                m.append(f'{field.name}={j}')
+        return ','.join(m)
+
+
+@dataclasses.dataclass
 class Cpe:
     ANY = CpeAny()
     PART = CpePart
@@ -33,7 +63,7 @@ class Cpe:
     sw_edition: str | CpeAny | None = dataclasses.field(default=ANY)
     target_sw: str | CpeAny | None = dataclasses.field(default=ANY)
     target_hw: str | CpeAny | None = dataclasses.field(default=ANY)
-    other: str | CpeAny | None = dataclasses.field(default=ANY)
+    other: str | CpeOtherDebian | CpeAny | None = dataclasses.field(default=ANY)
 
     __re = re.compile(r'''
         ^cpe:2.3:
@@ -63,6 +93,9 @@ class Cpe:
 
     __re_quote = re.compile(r'''([!"#$%&'()+,/:;<=>@[\]^`{|}~])''')
     __re_unquote = re.compile(r'''\\([!"#$%&'()+,/:;<=>@[\]^`{|}~])''')
+
+    def __post_init__(self) -> None:
+        self.other = CpeOtherDebian.parse(self)
 
     @classmethod
     def _parse_one(cls, field: dataclasses.Field, v: str, /) -> Any:
@@ -96,10 +129,8 @@ class Cpe:
                 m[field.name] = '-'
             elif isinstance(j, CpeAny):
                 m[field.name] = '*'
-            elif isinstance(j, str):
-                m[field.name] = self.__re_quote.sub(r'\\\1', j)
             else:
-                m[field.name] = str(j)
+                m[field.name] = self.__re_quote.sub(r'\\\1', str(j))
         return 'cpe:2.3:{part}:{vendor}:{product}:{version}:{update}:*:{lang}:{sw_edition}:{target_sw}:{target_hw}:{other}'.format(**m)
 
 

--- a/tests/cli/test_combine_deb.py
+++ b/tests/cli/test_combine_deb.py
@@ -44,7 +44,7 @@ class TestIngestDebsrc:
         assert t.deb_version == '1'
         assert t.debsec_vulnerable is False
         assert t.data_cpe_match == {
-            'criteria': 'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:*',
+            'criteria': r'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:deb_source\=test\,deb_version\=1',
             'vulnerable': False,
         }
 
@@ -67,7 +67,7 @@ class TestIngestDebsrc:
         assert t.deb_version == '1'
         assert t.debsec_vulnerable is True
         assert t.data_cpe_match == {
-            'criteria': 'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:*',
+            'criteria': r'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:deb_source\=test\,deb_version\=1',
             'vulnerable': True,
         }
 
@@ -91,7 +91,7 @@ class TestIngestDebsrc:
         assert t.deb_version == '1'
         assert t.debsec_vulnerable is False
         assert t.data_cpe_match == {
-            'criteria': 'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:*',
+            'criteria': r'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:deb_source\=test\,deb_version\=1',
             'vulnerable': False,
         }
 
@@ -115,6 +115,6 @@ class TestIngestDebsrc:
         assert t.deb_version == '1'
         assert t.debsec_vulnerable is True
         assert t.data_cpe_match == {
-            'criteria': 'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:*',
+            'criteria': r'cpe:2.3:o:debian:debian_linux:13:*:*:*:*:*:*:deb_source\=test\,deb_version\=1',
             'vulnerable': True,
         }

--- a/tests/data/test_cpe.py
+++ b/tests/data/test_cpe.py
@@ -33,3 +33,20 @@ class TestCpe:
         assert c.target_hw is Cpe.ANY
         assert c.other is Cpe.ANY
         assert str(c) == s
+
+    def test_debian(self):
+        s = r'cpe:2.3:o:debian:debian_linux:12:d:*:-:-:-:*:deb_source\=hello\,deb_version\=1'
+        c = Cpe.parse(s)
+
+        assert c.part is CpePart.OS
+        assert c.vendor == 'debian'
+        assert c.product == 'debian_linux'
+        assert c.version == '12'
+        assert c.update == 'd'
+        assert c.lang is None
+        assert c.sw_edition is None
+        assert c.target_sw is None
+        assert c.target_hw is Cpe.ANY
+        assert c.other.deb_source == 'hello'
+        assert c.other.deb_version == '1'
+        assert str(c) == s


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to use CPE to select on granularity of source packages. So add that information as extension to standard CPE.