### PR TITLE
Remove support for database connection in tests

### DIFF
--- a/tests/cli/test_ingest_nvd.py
+++ b/tests/cli/test_ingest_nvd.py
@@ -7,7 +7,7 @@ from glvd.database import NvdCve
 
 
 class TestIngestNvd:
-    async def test_fetch_cve_empty(self, db_conn, requests_mock):
+    async def test_fetch_cve_empty(self, db_session, requests_mock):
         for i in range(2):
             requests_mock.get(
                 f'https://services.nvd.nist.gov/rest/json/cves/2.0/?startIndex={i}',
@@ -41,9 +41,11 @@ class TestIngestNvd:
         )
 
         ingest = IngestNvd(wait=0)
-        await ingest.fetch_cve(db_conn)
+        await ingest.fetch_cve(db_session)
 
-        r = (await db_conn.execute(select(NvdCve).order_by(NvdCve.cve_id))).all()
+        r = (await db_session.execute(select(NvdCve).order_by(NvdCve.cve_id))).all()
         assert len(r) == 2
-        assert r[0].cve_id == 'TEST-0'
-        assert r[1].cve_id == 'TEST-1'
+        t = r.pop(0)[0]
+        assert t.cve_id == 'TEST-0'
+        t = r.pop(0)[0]
+        assert t.cve_id == 'TEST-1'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,18 +63,6 @@ async def db_engine():
 
 
 @pytest.fixture
-async def db_conn(db_engine):
-    '''
-    Provides an asynchronous SQLAlchemy database connection.
-
-    This should never be commited, or it will affect other tests.
-    '''
-    async with db_engine.begin() as conn:
-        yield conn
-        await conn.rollback()
-
-
-@pytest.fixture
 async def db_session(db_engine):
     '''
     Provides an asynchronous SQLAlchemy database session.

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -7,18 +7,18 @@ import contextlib
 from glvd.web import create_app
 
 
-@pytest.fixture()
-def app(db_conn):
+@pytest.fixture(scope='class')
+def app(db_session_class):
     app = create_app()
 
     @contextlib.asynccontextmanager
     async def db_begin():
-        yield db_conn
+        yield db_session_class
     setattr(app, 'db_begin', db_begin)
 
     yield app
 
 
-@pytest.fixture()
+@pytest.fixture(scope='class')
 def client(app):
     return app.test_client()

--- a/tests/web/test_nvd_cve.py
+++ b/tests/web/test_nvd_cve.py
@@ -4,25 +4,23 @@ import pytest
 
 from datetime import datetime
 
-from sqlalchemy import insert
-
 from glvd.database import NvdCve
 
 
 class TestNvdCve:
-    @pytest.fixture(autouse=True)
-    async def setup_example(self, db_conn):
+    @pytest.fixture(autouse=True, scope='class')
+    async def setup_example(self, db_session_class):
         for i in range(2):
-            insert_stmt = insert(NvdCve).values(
+            db_session_class.add(NvdCve(
                 cve_id=f'TEST-{i}',
                 last_mod=datetime.fromisoformat('2019-04-01T00:00:00'),
                 data={
                     'id': f'TEST-{i}',
                 },
-            )
-            await db_conn.execute(insert_stmt)
+            ))
+        await db_session_class.flush()
 
-    async def test_deb_cveid_simple(self, client, db_conn):
+    async def test_deb_cveid_simple(self, client):
         resp = await client.get(
             '/rest/json/cves/2.0+deb',
             query_string={
@@ -43,7 +41,7 @@ class TestNvdCve:
             ],
         }
 
-    async def test_deb_cveid_nonexist(self, client, db_conn):
+    async def test_deb_cveid_nonexist(self, client):
         resp = await client.get(
             '/rest/json/cves/2.0+deb',
             query_string={


### PR DESCRIPTION
**What this PR does / why we need it**:
SQLAlchemy supports two interfaces to work with databases, connection and session. In SQLAlchemy those where kind of combined, so a session can now also act as a connection. To make the tests easier, let's always use a session here.