### PR TITLE
Drop special case of ANY in CPE object

### DIFF
--- a/tests/data/test_cpe.py
+++ b/tests/data/test_cpe.py
@@ -7,16 +7,16 @@ class TestCpe:
     def test_init(self):
         c = Cpe()
 
-        assert c.part is Cpe.ANY
-        assert c.vendor is Cpe.ANY
-        assert c.product is Cpe.ANY
-        assert c.version is Cpe.ANY
-        assert c.update is Cpe.ANY
-        assert c.lang is Cpe.ANY
-        assert c.sw_edition is Cpe.ANY
-        assert c.target_sw is Cpe.ANY
-        assert c.target_hw is Cpe.ANY
-        assert c.other is Cpe.ANY
+        assert c.part is None
+        assert c.vendor is None
+        assert c.product is None
+        assert c.version is None
+        assert c.update is None
+        assert c.lang is None
+        assert c.sw_edition is None
+        assert c.target_sw is None
+        assert c.target_hw is None
+        assert c.other is None
         assert c.is_debian is False
 
     def test_parse(self):
@@ -28,16 +28,16 @@ class TestCpe:
         assert c.product == 'b'
         assert c.version == 'c:%\\*;c'
         assert c.update == 'd'
-        assert c.lang is None
-        assert c.sw_edition is None
-        assert c.target_sw is None
-        assert c.target_hw is Cpe.ANY
-        assert c.other is Cpe.ANY
+        assert c.lang == '-'
+        assert c.sw_edition == '-'
+        assert c.target_sw == '-'
+        assert c.target_hw is None
+        assert c.other is None
         assert c.is_debian is False
         assert str(c) == s
 
     def test_debian(self):
-        s = r'cpe:2.3:o:debian:debian_linux:12:d:*:-:-:-:*:deb_source\=hello\,deb_version\=1'
+        s = r'cpe:2.3:o:debian:debian_linux:12:d:*:*:*:*:*:deb_source\=hello\,deb_version\=1'
         c = Cpe.parse(s)
 
         assert c.part is CpePart.OS
@@ -48,7 +48,7 @@ class TestCpe:
         assert c.lang is None
         assert c.sw_edition is None
         assert c.target_sw is None
-        assert c.target_hw is Cpe.ANY
+        assert c.target_hw is None
         assert c.other.deb_source == 'hello'
         assert c.other.deb_version == '1'
         assert c.is_debian is True


### PR DESCRIPTION
**What this PR does / why we need it**:
The CPE object had special cases both for `ANY` and for `NA`. But it turns out that `NA` is not really necessary and `ANY` can then be moved to use Python `None`.