### PR TITLE
Generate JSON responses inside the database

### DIFF
--- a/src/glvd/database/__init__.py
+++ b/src/glvd/database/__init__.py
@@ -23,9 +23,9 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql import func
 from sqlalchemy.types import (
     DateTime,
+    JSON,
     Text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
 
 from .types import DebVersion
 
@@ -34,7 +34,7 @@ class Base(MappedAsDataclass, DeclarativeBase):
     type_annotation_map = {
         str: Text,
         datetime: DateTime(timezone=True),
-        Any: JSONB,
+        Any: JSON,
     }
 
 

--- a/tests/web/test_nvd_cve.py
+++ b/tests/web/test_nvd_cve.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+import json
+
 from glvd.database import AllCve
 
 
@@ -26,7 +28,7 @@ class TestNvdCve:
         )
 
         assert resp.status_code == 200
-        assert (await resp.json) == {
+        assert json.loads((await resp.data)) == {
             'format': 'NVD_CVE',
             'version': '2.0+deb',
             'vulnerabilities': [
@@ -47,7 +49,7 @@ class TestNvdCve:
         )
 
         assert resp.status_code == 200
-        assert (await resp.json) == {
+        assert json.loads((await resp.data)) == {
             'format': 'NVD_CVE',
             'version': '2.0+deb',
             'vulnerabilities': []


### PR DESCRIPTION
**What this PR does / why we need it**:
PostgreSQL can actually generate JSON objects from scratch and aggregate existing JSON fields as well into lists.  While it might not be faster, it frees the currently single threaded web server.

Also we need to use JSON instead of JSONB.  The queries run about 50% faster and we don't manipulate JSON any further in the database anyway.
