### PR TITLE
Use Hypercorn as production ASGI server

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,9 +3,9 @@ FROM docker.io/library/debian:trixie-slim
 # XXX: Debian Experimental required for python3-sqlalchemy (>= 2)
 RUN sed -i -e 's/Suites: trixie trixie-updates/\0 experimental/' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update && \
-    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-pip python3-poetry-core python3-quart python3-requests python3-sqlalchemy/experimental
+    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-hypercorn python3-pip python3-poetry-core python3-quart python3-requests python3-sqlalchemy/experimental
 COPY . /usr/local/src
 RUN pip install --break-system-packages --no-deps --editable /usr/local/src
 
-# TODO: The Quart internal server is only for development
-CMD ["quart",  "--app=glvd.web", "run", "--host=::"]
+ENTRYPOINT ["hypercorn", "glvd.web.app:app"]
+CMD []

--- a/src/glvd/web/app.py
+++ b/src/glvd/web/app.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+
+from . import create_app
+
+
+app = create_app()


### PR DESCRIPTION
**What this PR does / why we need it**:
The internal server in Quart is not supposed to be used for production. Use Hypercorn instead.
