### PR TITLE
Make web interface also type safe

### DIFF
--- a/src/glvd/data/cpe.py
+++ b/src/glvd/data/cpe.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import dataclasses
 import re
 from enum import StrEnum
-from typing import Any
+from typing import (
+    Any,
+    cast,
+)
 
 
 class CpePart(StrEnum):
@@ -100,6 +103,12 @@ class Cpe:
                 self.other = CpeOtherDebian.parse(self.other)
             elif self.other is None:
                 self.other = CpeOtherDebian()
+
+    @property
+    def other_debian(self) -> CpeOtherDebian:
+        if self.is_debian:
+            return cast(CpeOtherDebian, self.other)
+        raise TypeError('Not debian related CPE')
 
     @classmethod
     def _parse_one(cls, field: dataclasses.Field, v: str, /) -> Any:

--- a/tests/data/test_cpe.py
+++ b/tests/data/test_cpe.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+import pytest
+
 from glvd.data.cpe import Cpe, CpePart
 
 
@@ -18,6 +20,8 @@ class TestCpe:
         assert c.target_hw is None
         assert c.other is None
         assert c.is_debian is False
+        with pytest.raises(TypeError):
+            c.other_debian
 
     def test_parse(self):
         s = r'cpe:2.3:h:a:b:c\:\%\*\;c:d:*:-:-:-:*:*'
@@ -34,6 +38,8 @@ class TestCpe:
         assert c.target_hw is None
         assert c.other is None
         assert c.is_debian is False
+        with pytest.raises(TypeError):
+            c.other_debian
         assert str(c) == s
 
     def test_debian(self):
@@ -49,8 +55,8 @@ class TestCpe:
         assert c.sw_edition is None
         assert c.target_sw is None
         assert c.target_hw is None
-        assert c.other.deb_source == 'hello'
-        assert c.other.deb_version == '1'
+        assert c.other_debian.deb_source == 'hello'
+        assert c.other_debian.deb_version == '1'
         assert c.is_debian is True
         assert str(c) == s
 
@@ -58,7 +64,7 @@ class TestCpe:
         s = r'cpe:2.3:o:debian:debian_linux:12:d:*:*:*:*:*:*'
         c = Cpe.parse(s)
 
-        assert c.other.deb_source is None
-        assert c.other.deb_version is None
+        assert c.other_debian.deb_source is None
+        assert c.other_debian.deb_version is None
         assert c.is_debian is True
         assert str(c) == s


### PR DESCRIPTION
**What this PR does / why we need it**:
The web interface implementation lacked any type definitions, so all code was unchecked. Fix that and make the CPE class better usable for this case.