### PR TITLE
Disable echo in SQLAlchemy

### DIFF
--- a/src/glvd/cli/combine_all.py
+++ b/src/glvd/cli/combine_all.py
@@ -109,7 +109,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     engine = create_async_engine(
         "postgresql+asyncpg:///",
-        echo=True,
     )
     main = CombineDeb()
     asyncio.run(main(engine))

--- a/src/glvd/cli/combine_deb.py
+++ b/src/glvd/cli/combine_deb.py
@@ -173,7 +173,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     engine = create_async_engine(
         "postgresql+asyncpg:///",
-        echo=True,
     )
     main = CombineDeb()
     asyncio.run(main(engine))

--- a/src/glvd/cli/ingest_debsec.py
+++ b/src/glvd/cli/ingest_debsec.py
@@ -134,7 +134,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     engine = create_async_engine(
         "postgresql+asyncpg:///",
-        echo=True,
     )
     ingest = IngestDebsec(args.cpe_product, args.dir)
     asyncio.run(ingest(engine))

--- a/src/glvd/cli/ingest_debsrc.py
+++ b/src/glvd/cli/ingest_debsrc.py
@@ -126,7 +126,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     engine = create_async_engine(
         "postgresql+asyncpg:///",
-        echo=True,
     )
     ingest = IngestDebsrc(args.cpe_product, args.deb_codename, args.file)
     asyncio.run(ingest(engine))

--- a/src/glvd/cli/ingest_nvd.py
+++ b/src/glvd/cli/ingest_nvd.py
@@ -123,7 +123,6 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     engine = create_async_engine(
         "postgresql+asyncpg:///",
-        # echo=True,
     )
     ingest = IngestNvd()
     asyncio.run(ingest(engine))

--- a/src/glvd/web/__init__.py
+++ b/src/glvd/web/__init__.py
@@ -14,7 +14,6 @@ class QuartDb:
         # TODO: Use config
         self.engine = create_async_engine(
             "postgresql+asyncpg:///",
-            echo=True,
             pool_size=50,
             max_overflow=0,
         )


### PR DESCRIPTION
**What this PR does / why we need it**:
SQLAlchemy can echo all queries it is executing to the log. This is just a debugging aid, so let's disable it now.