### PR TITLE
Temporarily ignore result from broken flake8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
 
     - name: Run flake8
       if: success() || failure()
+      # flake8 is broken right now: https://bugs.debian.org/1057968
+      continue-on-error: true
       run: >
         docker run
         --network host


### PR DESCRIPTION
**What this PR does / why we need it**:
The flake8 package in Debian Trixie is currently broken (see [https://bugs.debian.org/1057968](#1057968)). Temporarily ignore it's status.