### PR TITLE
Fix program name for CLI commands

### DIFF
--- a/src/glvd/cli/client/__init__.py
+++ b/src/glvd/cli/client/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..registry import CliRegistry
 
 
-cli = CliRegistry()
+cli = CliRegistry('glvd')
 
 cli.add_argument(
     '--server',

--- a/src/glvd/cli/data/__init__.py
+++ b/src/glvd/cli/data/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..registry import CliRegistry
 
 
-cli = CliRegistry()
+cli = CliRegistry('glvd-data')
 
 cli.add_argument(
     '--database',

--- a/src/glvd/cli/registry.py
+++ b/src/glvd/cli/registry.py
@@ -21,10 +21,10 @@ class CliRegistry:
 
     arguments: list[_ActionWrapper]
 
-    def __init__(self) -> None:
+    def __init__(self, name: str) -> None:
         self.parser = argparse.ArgumentParser(
             allow_abbrev=False,
-            prog='glvd',
+            prog=name,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
         self.subparsers = self.parser.add_subparsers(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that the right program name is shown while executing glvd's CLI commands

**Which issue(s) this PR fixes**:
Fixes #55

