### PR TITLE
Change default glvd server to glvd.gardenlinux.io

### DIFF
--- a/src/glvd/cli/client/__init__.py
+++ b/src/glvd/cli/client/__init__.py
@@ -9,7 +9,7 @@ cli = CliRegistry('glvd')
 
 cli.add_argument(
     '--server',
-    default='http://localhost:5000',
+    default='http://glvd.gardenlinux.io',
     help='the server to use',
 )
 cli.add_argument(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the default server for `glvd` to `glvd.gardenlinux.io`

**Which issue(s) this PR fixes**:
Fixes #62 
