### PR TITLE
Fix image build: sqlalchemy >= 2.0 is now in unstable

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,9 @@
 FROM docker.io/library/debian:trixie-slim
 
-# XXX: Debian Experimental required for python3-sqlalchemy (>= 2)
-RUN sed -i -e 's/Suites: trixie trixie-updates/\0 experimental/' /etc/apt/sources.list.d/debian.sources
+# XXX: Debian unstable required for python3-sqlalchemy (>= 2)
+RUN sed -i -e 's/Suites: trixie trixie-updates/\0 unstable/' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update && \
-    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-hypercorn python3-pip python3-poetry-core python3-quart python3-requests python3-sqlalchemy/experimental
+    apt-get upgrade -y --no-install-recommends python3-asyncpg python3-hypercorn python3-pip python3-poetry-core python3-quart python3-requests python3-sqlalchemy/unstable
 COPY . /usr/local/src
 RUN pip install --break-system-packages --no-deps --editable /usr/local/src
 


### PR DESCRIPTION
cf https://metadata.ftp-master.debian.org/changelogs//main/s/sqlalchemy/sqlalchemy_2.0.30+ds1-3_changelog
